### PR TITLE
Remove HTML support for descriptions

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -85,11 +85,13 @@ venues << Venue.new(:name => 'Bottom of the Hill', :link => 'http://www.bottomof
         Time.parse(time, date)
       end.min
       time ||= Time.parse('12:00pm', date)
+      fragment = Nokogiri::HTML.fragment(item.description)
+      fragment.css('br').each { |node| node.replace(' / ') }
       show(
         :time => time,
         :link => item.link,
         :title => item.title.partition(':').last.strip,
-        :description => item.description
+        :description => fragment.text.strip
       )
     end
   end
@@ -225,12 +227,6 @@ shows.sort_by!(&:time)
 
 include ERB::Util
 
-def normalize(text)
-  fragment = Nokogiri::HTML.fragment(text)
-  fragment.css('br').each { |node| node.replace(' / ') }
-  h(fragment.text.strip)
-end
-
 ERB.new(<<~ERB).run
   <!doctype html>
   <html>
@@ -267,16 +263,16 @@ ERB.new(<<~ERB).run
             </td>
             <td valign="top">
               <p>
-                <strong><a href="<%= h(show.link) %>"><%= normalize(show.title) %></a></strong>
+                <strong><a href="<%= h(show.link) %>"><%= h(show.title) %></a></strong>
                 <br>
-                <%= normalize(show.description) %>
+                <%= h(show.description) %>
                 <br>
                 <a href="<%= show.ical_link %>">iCal</a>
               </p>
             </td>
             <td nowrap valign="top">
               <p>
-                <a href="<%= h(show.venue.link) %>"><%= normalize(show.venue.name) %></a>
+                <a href="<%= h(show.venue.link) %>"><%= h(show.venue.name) %></a>
               </p>
             </td>
           </tr>

--- a/index.rb
+++ b/index.rb
@@ -256,9 +256,11 @@ ERB.new(<<~ERB).run
           <tr data-venue="<%= h(show.venue.object_id) %>">
             <td nowrap valign="top">
               <p>
-                <%= show.time.strftime('%a, %b %-d') %>
-                <br>
-                <%= show.time.strftime('%l:%M%P') %>
+                <a href="<%= h(show.ical_link) %>">
+                  <%= show.time.strftime('%a, %b %-d') %>
+                  <br>
+                  <%= show.time.strftime('%l:%M%P') %>
+                </a>
               </p>
             </td>
             <td valign="top">
@@ -266,8 +268,6 @@ ERB.new(<<~ERB).run
                 <strong><a href="<%= h(show.link) %>"><%= h(show.title) %></a></strong>
                 <br>
                 <%= h(show.description) %>
-                <br>
-                <a href="<%= show.ical_link %>">iCal</a>
               </p>
             </td>
             <td nowrap valign="top">


### PR DESCRIPTION
I added `normalize` in the [first commit][0], because Bottom of the Hill
uses line break tags in their RSS feed and I wanted it all on one line.
HTML descriptions are breaking iCalendar links, though, and I think it
makes more sense to have venues handle removing HTML if necessary. As
far as I can tell, only Bottom of the Hill returns HTML descriptions.
`h` handles escaping any HTML that isn't removed.

[0]: https://github.com/davishmcclurg/shows/commit/35a17f7228bbfd3e9148d8361a80eb0084af8e0f