### PR TITLE
Parse title for backup date for bottom of the hill

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -118,7 +118,8 @@ venues << Venue.new(:name => 'Bottom of the Hill', :link => 'http://www.bottomof
     RSS::Parser.parse(rss).items.group_by(&:link).transform_values do |items|
       items.max_by(&:date)
     end.map do |date, item|
-      date = Date.parse(item.link[/\d+/])
+      backup_date, _delimiter, title = item.title.partition(':').map(&:strip)
+      date = Date.parse(item.link[/\d+/]) rescue Date.parse(backup_date)
       time = item.description.scan(/\d{1,2}(?:\:\d{2})?\s*[ap]m/i).map do |time|
         Time.parse(time, date)
       end.min
@@ -128,7 +129,7 @@ venues << Venue.new(:name => 'Bottom of the Hill', :link => 'http://www.bottomof
       show(
         :time => time,
         :link => item.link,
-        :title => item.title.partition(':').last.strip,
+        :title => title,
         :description => fragment.text.strip
       )
     end


### PR DESCRIPTION
One of the RSS items has an invalid URL `link`:

```xml
<link>http://www.bottomofthehill.com/202309112.html</link>
```

Looks like an extra digit in the date. This rescues the error and parses the date from the title if the link doesn't work.

Original error:

```
 index.rb:121:in `parse': invalid date (Date::Error)

      date = Date.parse(item.link[/\d+/])
                        ^^^^^^^^^^^^^^^^
	from index.rb:121:in `block (3 levels) in <main>'
	from index.rb:120:in `each'
	from index.rb:120:in `map'
	from index.rb:120:in `block (2 levels) in <main>'
```